### PR TITLE
load games from special source-books index

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -36,18 +36,4 @@ async def create_message(messages: Messages):
 
 @app.get("/games")
 async def get_games():
-    response = elastic_request(
-        url="source-books/_search",
-        data={
-            "size": 0,
-            "aggs": {
-                "unique_games": {
-                    "terms": {
-                        "field": "game.keyword"
-                    }
-                }
-            }
-        }
-    ).json()
-    buckets = response.get("aggregations", {}).get("unique_games", {}).get("buckets", [])
-    return [bucket["key"] for bucket in buckets]
+    return unique_values("source-books", "game")

--- a/app/api.py
+++ b/app/api.py
@@ -1,7 +1,7 @@
 from typing import List, Dict, Literal
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
-from utils.elastic import elastic_request
+from utils.elastic import elastic_request, unique_values
 from pydantic import BaseModel
 
 from agents.adjudicator import query

--- a/app/frontend/src/__tests__/chat.test.js
+++ b/app/frontend/src/__tests__/chat.test.js
@@ -37,7 +37,7 @@ afterEach(() => {
 
 test('uses random question as placeholder when no messages are submitted', () => {
   render(<ChatInterface initialMessages={[]} />);
-  const input = screen.getByPlaceholderText(/e\.g\. "/);
+  const input = screen.getByPlaceholderText(/e\.g\. ".*"/);
   expect(input).toBeInTheDocument();
 });
 
@@ -71,7 +71,7 @@ test('handles Enter key press to send message', async () => {
 
   render(<ChatInterface />);
 
-  const input = screen.getByPlaceholderText(/^e\.g\. /);
+  const input = screen.getByPlaceholderText(/e\.g\. ".*"/);
 
   expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
 
@@ -123,7 +123,7 @@ test('submits message on Enter key press', async () => {
 
   render(<ChatInterface />);
 
-  const input = screen.getByPlaceholderText(/^e\.g\. /);
+  const input = screen.getByPlaceholderText(/e\.g\. ".*"/);
 
   expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
 
@@ -221,7 +221,7 @@ test('sends debug: true when checkbox is checked', async () => {
   const debugCheckbox = screen.getByLabelText('Debug Mode');
   fireEvent.click(debugCheckbox);
 
-  const input = screen.getByPlaceholderText(/^e\.g\. /);
+  const input = screen.getByPlaceholderText(/e\.g\. ".*"/);
   fireEvent.change(input, { target: { value: 'Test message' } });
   fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
 
@@ -603,7 +603,7 @@ test('conversations are retained when switching between games', async () => {
   expect(screen.queryByText('Otherscape message')).not.toBeInTheDocument();
 
   // Switch to Otherscape
-  const otherscapeButton = screen.getByText(':Otherscape');
+  const otherscapeButton = screen.getByText('Otherscape');
   fireEvent.click(otherscapeButton);
   
   // Check Otherscape messages

--- a/app/frontend/src/__tests__/chat.test.js
+++ b/app/frontend/src/__tests__/chat.test.js
@@ -464,7 +464,7 @@ test('shows loading spinner while fetching games', async () => {
   
   // Games should be rendered
   expect(screen.getByText('Dungeons & Dragons 5th Edition')).toBeInTheDocument();
-  expect(screen.getByText(':Otherscape')).toBeInTheDocument();
+  expect(screen.getByText('Otherscape')).toBeInTheDocument();
 
   fetchMock.mockRestore();
 });

--- a/app/frontend/src/__tests__/chat.test.js
+++ b/app/frontend/src/__tests__/chat.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { waitForElementToBeRemoved } from '@testing-library/react';
 import dndQuestions from '../dnd-5e-questions.json';
 import otherscapeQuestions from '../otherscape-questions.json';
 import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
@@ -439,7 +440,7 @@ test('switching games clears the conversation', () => {
   expect(screen.getByText('D&D message')).toBeInTheDocument();
   
   // Switch to Otherscape
-  const otherscapeButton = screen.getByText(':Otherscape');
+  const otherscapeButton = screen.getByText('Dungeons & Dragons 5th Edition');
   fireEvent.click(otherscapeButton);
   
   // Verify D&D message is no longer shown
@@ -462,7 +463,7 @@ test('shows loading spinner while fetching games', async () => {
   await waitForElementToBeRemoved(() => screen.queryByLabelText('Loading games...'));
   
   // Games should be rendered
-  expect(screen.getByText('dnd-5e')).toBeInTheDocument();
+  expect(screen.getByText('Dungeons & Dragons 5th Edition')).toBeInTheDocument();
   expect(screen.getByText(':Otherscape')).toBeInTheDocument();
 
   fetchMock.mockRestore();
@@ -470,7 +471,7 @@ test('shows loading spinner while fetching games', async () => {
 
 test('loads settings from URL parameters', () => {
   // Set URL parameters for this test
-  window.location = { ...window.location, search: '?game=otherscape&debug=true&model=gpt-4o&knn=0.6&keywords=0.4' };
+  window.location = { ...window.location, search: '?game=Dungeons%20%26%20Dragons%205th%20Edition&debug=true&model=gpt-4o&knn=0.6&keywords=0.4' };
 
   render(<ChatInterface />);
 
@@ -501,7 +502,7 @@ test('shows appropriate example questions for D&D 5e', () => {
 });
 
 test('shows appropriate example questions for Otherscape', () => {
-  window.location = { ...window.location, search: '?game=:Otherscape' };
+  window.location = { ...window.location, search: '?game=Dungeons%20%26%20Dragons%205th%20Edition' };
   
   render(<ChatInterface />);
   

--- a/app/frontend/src/__tests__/chat.test.js
+++ b/app/frontend/src/__tests__/chat.test.js
@@ -480,7 +480,7 @@ test('loads settings from URL parameters', () => {
   fireEvent.click(settingsButton);
 
   // Verify all settings match URL parameters
-  expect(screen.getByText(':Otherscape')).toHaveClass('selected');
+  expect(screen.getByText('Dungeons & Dragons 5th Edition')).toHaveClass('selected');
   expect(screen.getByLabelText('Debug Mode')).toBeChecked();
   expect(screen.getByLabelText('Model')).toHaveValue('gpt-4o');
   const knnSlider = screen.getByLabelText(/KNN Weight/);

--- a/app/frontend/src/chat.js
+++ b/app/frontend/src/chat.js
@@ -312,7 +312,7 @@ const ChatInterface = ({ initialMessages = [] }) => {
           <button
             onClick={handleSendMessage}
             className="send-button"
-            disabled={messages.length > 0 && newMessage.trim() === ''}
+            disabled={(messages.length > 0 || !randomExampleQuestion) && newMessage.trim() === ''}
           >
             Send
           </button>

--- a/app/frontend/src/chat.js
+++ b/app/frontend/src/chat.js
@@ -59,8 +59,21 @@ const ChatInterface = ({ initialMessages = [] }) => {
     const savedMessages = localStorage.getItem(`chat-history-${urlParams.game}`);
     return savedMessages ? JSON.parse(savedMessages) : initialMessages;
   });
-  const exampleQuestions = game === 'dnd-5e' ? dndQuestions : otherscapeQuestions;
-  const randomExampleQuestion = exampleQuestions[Math.floor(Math.random() * exampleQuestions.length)]
+  const getExampleQuestions = (gameName) => {
+    switch (gameName) {
+      case 'Dungeons & Dragons 5th Edition':
+        return dndQuestions;
+      case ':Otherscape':
+        return otherscapeQuestions;
+      default:
+        return [];
+    }
+  };
+
+  const exampleQuestions = getExampleQuestions(game);
+  const randomExampleQuestion = exampleQuestions.length > 0 
+    ? exampleQuestions[Math.floor(Math.random() * exampleQuestions.length)]
+    : '';
 
   const messageInputRef = useRef(null);
   const [newMessage, setNewMessage] = useState('');
@@ -269,7 +282,7 @@ const ChatInterface = ({ initialMessages = [] }) => {
           <textarea
             value={newMessage}
             onChange={(e) => setNewMessage(e.target.value)}
-            placeholder={messages.length > 0 ? "Type new message..." : `e.g. "${randomExampleQuestion}"`}
+            placeholder={messages.length > 0 ? "Type new message..." : randomExampleQuestion ? `e.g. "${randomExampleQuestion}"` : "Type your message..."}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();

--- a/app/frontend/src/chat.js
+++ b/app/frontend/src/chat.js
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
 import dndQuestions from './dnd-5e-questions.json';
 import otherscapeQuestions from './otherscape-questions.json';
+import './chat.css';
 
 const API_URL = process.env.NODE_ENV === 'production' 
   ? 'https://chat-rpg.ai/api' 
   : process.env.REACT_APP_API_HOST || 'http://localhost:8000';
-import './chat.css';
 
 const getUrlParams = () => {
   const params = new URLSearchParams(window.location.search);

--- a/app/frontend/src/chat.js
+++ b/app/frontend/src/chat.js
@@ -37,7 +37,7 @@ const updateUrl = (params) => {
 const ChatInterface = ({ initialMessages = [] }) => {
   const urlParams = getUrlParams();
   const [game, setGame] = useState(urlParams.game);
-  const [games, setGames] = useState([]);
+  const [games, setGames] = useState(['dnd-5e']); // Default game as fallback
   const [loadingGames, setLoadingGames] = useState(true);
 
   useEffect(() => {
@@ -74,8 +74,7 @@ const ChatInterface = ({ initialMessages = [] }) => {
   const [controlsVisible, setControlsVisible] = useState(false);
 
   const getFormattedGameName = () => {
-    const currentGame = games.find(g => g.id === game);
-    return currentGame ? currentGame.displayName : 'the RPG';
+    return game || 'the RPG';
   };
 
   const handleSliderChange = (type, value) => {
@@ -207,22 +206,22 @@ const ChatInterface = ({ initialMessages = [] }) => {
         {loadingGames ? (
           <div className="spinner" aria-label="Loading games..." />
         ) : (
-          games.map(({ id, name, displayName }) => (
+          games.map((gameName) => (
             <button
-              key={id}
-              className={`game-option ${game === id ? 'selected' : ''}`}
+              key={gameName}
+              className={`game-option ${game === gameName ? 'selected' : ''}`}
               onClick={() => {
                 // Save current chat before switching
                 if (messages.length > 0) {
                   localStorage.setItem(`chat-history-${game}`, JSON.stringify(messages));
                 }
-                setGame(id);
+                setGame(gameName);
                 // Load chat history for new game or start fresh
-                const savedMessages = localStorage.getItem(`chat-history-${id}`);
+                const savedMessages = localStorage.getItem(`chat-history-${gameName}`);
                 setMessages(savedMessages ? JSON.parse(savedMessages) : []);
               }}
             >
-              {displayName}
+              {gameName}
             </button>
           ))
         )}

--- a/elastic_scratchpad.ipynb
+++ b/elastic_scratchpad.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,14 +25,104 @@
     "    if data:\n",
     "        data = json.dumps(data)    \n",
     "\n",
-    "    return method(f\"https://192.168.1.153:9200/{url}\",\n",
+    "    return method(f\"{os.getenv('ELASTIC_HOST')}/{url}\",\n",
     "                  headers={\n",
     "                    \"Content-Type\": \"application/json\",\n",
     "                    \"Accept\": \"application/json\",\n",
-    "                    \"Authorization\": f\"ApiKey {os.getenv('ELASTIC_API_KEY')}\"\n",
+    "                    \"Authorization\": f\"ApiKey {os.getenv('K8S_ELASTIC_API_KEY')}\"\n",
     "                  },\n",
     "                  verify=False,\n",
     "                  data=data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/workspaces/llm-dungeon-master/versions/lib/python3.12/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'acknowledged': True}"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rslt = elastic_request(method=requests.put, url=\"source-books/_mapping\", data={\n",
+    "  \"properties\": {\n",
+    "    \"title\": {\n",
+    "        \"type\": \"keyword\"\n",
+    "    },\n",
+    "    \"game\": {\n",
+    "      \"type\": \"keyword\",\n",
+    "    },\n",
+    "    \"index\": {\n",
+    "      \"type\": \"keyword\"\n",
+    "    }\n",
+    "  }\n",
+    "})\n",
+    "rslt.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/workspaces/llm-dungeon-master/versions/lib/python3.12/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'took': 10,\n",
+       " 'timed_out': False,\n",
+       " 'total': 10,\n",
+       " 'updated': 0,\n",
+       " 'created': 10,\n",
+       " 'deleted': 0,\n",
+       " 'batches': 1,\n",
+       " 'version_conflicts': 0,\n",
+       " 'noops': 0,\n",
+       " 'retries': {'bulk': 0, 'search': 0},\n",
+       " 'throttled_millis': 0,\n",
+       " 'requests_per_second': -1.0,\n",
+       " 'throttled_until_millis': 0,\n",
+       " 'failures': []}"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rslt = elastic_request(method=requests.post, url=\"_reindex\", data={\n",
+    "  \"source\": {\n",
+    "    \"index\": \"source-books2\"\n",
+    "  },\n",
+    "  \"dest\": {\n",
+    "    \"index\": \"source-books\"\n",
+    "  }\n",
+    "})\n",
+    "rslt.json()"
    ]
   },
   {
@@ -305,7 +395,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "versions",
    "language": "python",
    "name": "python3"
   },
@@ -319,7 +409,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/utils/elastic.py
+++ b/utils/elastic.py
@@ -20,3 +20,10 @@ def elastic_request(data=None, method=None, url=None, headers=None):
     },
         verify=False,
         data=data)
+
+
+def unique_values(index, field):
+    return elastic_request(
+        url=f"{index}/_search",
+        data={"aggs": {f"{field}": {"terms": {"field": field}}}}
+    )

--- a/utils/elastic.py
+++ b/utils/elastic.py
@@ -23,7 +23,17 @@ def elastic_request(data=None, method=None, url=None, headers=None):
 
 
 def unique_values(index, field):
-    return elastic_request(
+    response = elastic_request(
         url=f"{index}/_search",
-        data={"aggs": {f"{field}": {"terms": {"field": field}}}}
-    )
+        data={
+            "size": 0,
+            "aggs": {
+                "unique_values": {
+                    "terms": {
+                        "field": f"{field}.keyword"
+                    }
+                }
+            }
+        }
+    ).json()
+    return [bucket["key"] for bucket in response.get("aggregations", {}).get("unique_values", {}).get("buckets", [])]

--- a/utils/elastic.py
+++ b/utils/elastic.py
@@ -28,12 +28,12 @@ def unique_values(index, field):
         data={
             "size": 0,
             "aggs": {
-                "unique_values": {
+                field: {
                     "terms": {
-                        "field": f"{field}.keyword"
+                        "field": f"{field}"
                     }
                 }
             }
         }
     ).json()
-    return [bucket["key"] for bucket in response.get("aggregations", {}).get("unique_values", {}).get("buckets", [])]
+    return [bucket["key"] for bucket in response.get("aggregations", {}).get(field, {}).get("buckets", [])]

--- a/utils/ingest.py
+++ b/utils/ingest.py
@@ -137,14 +137,21 @@ def ingest(doc, title, index):
     return rslt
 
 
-def process_ingest(filepath, book_title):
+def add_to_source_books(game, book_title, index):
+    rslt = elastic_request(method=requests.put,
+                           url=f"source-books/_doc/{game}--{book_title}",
+                           data={"game": game, "title": book_title, "index": index})
+    return rslt
+
+
+def process_ingest(filepath, index, game_title, book_title):
     result = import_book(filepath)
     i = 0
     for rslt in without_subheadings(result):
         if not rslt.get("content"):
             continue
         title = rslt["heading"]
-        resp = ingest(rslt, title, book_title)
+        resp = ingest(rslt, title, index)
 
         try:
             resp.raise_for_status()
@@ -155,8 +162,9 @@ def process_ingest(filepath, book_title):
         i += 1
         if i % 10 == 0:
             print(rslt)
+    add_to_source_books(game_title, book_title, index)
 
 
 if __name__ == "__main__":
     process_ingest("/data/Dragonbane/dtrpg-2025-01-13_10-05pm/DB_Path_of_Glory_v1.pdf",
-                   "dragonbane--path-of-glory",)
+                   "dragonbane--path-of-glory", "Dragonbane", "Path of Glory")


### PR DESCRIPTION
This adds an implementation of a `source-books` index containing all of the independent source books that have been added. This index contains the title
of the book, the game it applies to, and the name of the index into which the book has been ingested.

It also adds an endpoint that can be used to fetch the set of games for which there exist source books, and configures the frontend to use it.